### PR TITLE
fix: use secure HttpOnly cookies for auth tokens

### DIFF
--- a/server/chorus/settings.py
+++ b/server/chorus/settings.py
@@ -1,3 +1,4 @@
+import os
 from typing import Annotated
 from fastapi import Depends
 from pydantic_settings import BaseSettings
@@ -9,9 +10,10 @@ class Settings(BaseSettings):
     secret_key: str
     algorithm: str = "HS256"
     expires_delta_seconds: int = 3600
+    cookie_secure: bool = True
 
     class Config:
-        env_file = ".env"
+        env_file = os.getenv("ENV_FILE", ".env")
 
 
 settings = Settings()

--- a/server/chorus/tests/test_conversation.py
+++ b/server/chorus/tests/test_conversation.py
@@ -164,7 +164,7 @@ class TestCreateConversation:
 
 
 class TestReadConversations:
-    def test_read_conversations_returns_empty_list(self, authenticated_clients, unique_token):
+    def test_read_conversations_returns_empty_list(self, authenticated_clients):
         """
         Test that an empty list is returned when a user has not created a conversation
         Expected Behavior:


### PR DESCRIPTION
## Summary
Changed /token and /register/anonymous endpoints to set authentication tokens in secure, HttpOnly cookies instead of returning them in the response body.

**Server changes**
- /token and /register/anonymous now use secure HttpOnly cookies. Response bodies no longer include tokens.
- /register/anonymous returns a message and session username.

**Testing changes:**
- Updated conftest.py to use test.env for testing.
- Added 'cookie_secure' flag in settings (default True) to allow secure cookies in production and disable in tests (TestClient uses HTTP only).
- Test fixtures modified to no longer read tokens from response bodies.

**General change:**
- Added support in settings for dynamically selecting the env file at runtime.

Fixes #45 