### PR TITLE
Fix bullet list rendering in markdown content

### DIFF
--- a/client/src/app/core/gh-markdown-css-edited.css
+++ b/client/src/app/core/gh-markdown-css-edited.css
@@ -320,8 +320,15 @@
   border-left: 0.25em solid #d1d9e0;
 }
 
-.markdown-body ul,
+.markdown-body ul {
+  list-style-type: disc;
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-left: 2em;
+}
+
 .markdown-body ol {
+  list-style-type: decimal;
   margin-top: 0;
   margin-bottom: 0;
   padding-left: 2em;


### PR DESCRIPTION
Fixes #79

Bullet points were not rendering in markdown content because the markdown stylesheet did not explicitly define list-style-type for unordered and ordered lists. This change restores bullet and numbered list markers within `.markdown-body`.